### PR TITLE
Claude/serene albattani 0 yt hg

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,12 +6,17 @@ services:
     volumes:
       - ./:/app
     command: --bind 0.0.0.0:5781 --reload
+    environment:
+      OTLP_ENDPOINT: http://jaeger:4317
   jaeger:
     image: jaegertracing/all-in-one:latest
     container_name: jaeger
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
     ports:
-      - "6831:6831/udp"
-      - "16686:16686"
+      - "4317:4317"   # OTLP gRPC
+      - "4318:4318"   # OTLP HTTP
+      - "16686:16686" # Jaeger UI
     networks:
       - strider
   hotrod:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,8 +6,6 @@ services:
     volumes:
       - ./:/app
     command: --bind 0.0.0.0:5781 --reload
-    environment:
-      OTLP_ENDPOINT: http://jaeger:4317
   jaeger:
     image: jaegertracing/all-in-one:latest
     container_name: jaeger

--- a/manage.py
+++ b/manage.py
@@ -121,25 +121,21 @@ def verify_locked(extra_args):
     """
 
     for src, locked in REQUIREMENTS_FILES.items():
-        dependencies = get_command_output(
-            f"""\
+        dependencies = get_command_output(f"""\
         docker run --rm -v $(pwd):/app python:3.12 \
             /bin/bash -c "
                 pip install -qqq -r /app/{locked} &&
                 pip install -qqq -r /app/{src}    &&
                 pip freeze
             "
-        """
-        )
-        lock_dependencies = get_command_output(
-            f"""\
+        """)
+        lock_dependencies = get_command_output(f"""\
         docker run -v $(pwd):/app python:3.12 \
             /bin/bash -c "
                 pip install -qqq -r /app/{locked} &&
                 pip freeze
             "
-        """
-        )
+        """)
 
         if dependencies != lock_dependencies:
             sys.exit(f"Lock file {locked} not up-to-date, please run ./manage.py lock")

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -36,13 +36,13 @@ markdown-it-py==3.0.0
 MarkupSafe==2.1.5
 mdurl==0.1.2
 opentelemetry-api==1.26.0
-opentelemetry-exporter-jaeger==1.21.0
-opentelemetry-exporter-jaeger-proto-grpc==1.21.0
-opentelemetry-exporter-jaeger-thrift==1.21.0
+opentelemetry-exporter-otlp-proto-common==1.26.0
+opentelemetry-exporter-otlp-proto-grpc==1.26.0
 opentelemetry-instrumentation==0.47b0
 opentelemetry-instrumentation-asgi==0.47b0
 opentelemetry-instrumentation-fastapi==0.47b0
 opentelemetry-instrumentation-httpx==0.47b0
+opentelemetry-proto==1.26.0
 opentelemetry-sdk==1.26.0
 opentelemetry-semantic-conventions==0.47b0
 opentelemetry-util-http==0.47b0
@@ -76,7 +76,6 @@ sniffio==1.3.1
 sortedcontainers==2.4.0
 starlette==0.37.2
 stringcase==1.2.0
-thrift==0.21.0
 typer==0.12.5
 typing_extensions==4.12.2
 ujson==5.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ gunicorn==22.0.0
 kp-registry==4.0.1
 opentelemetry-sdk==1.26.0
 opentelemetry-instrumentation-fastapi==0.47b0
-opentelemetry-exporter-jaeger==1.21.0
+opentelemetry-exporter-otlp-proto-grpc==1.26.0
 opentelemetry-instrumentation-httpx==0.47b0
 pyinstrument==4.6.2

--- a/strider/caching.py
+++ b/strider/caching.py
@@ -9,7 +9,6 @@ import redis.asyncio as aioredis
 
 from strider.config import settings
 
-
 onehop_redis_pool = aioredis.BlockingConnectionPool(
     host=settings.redis_host,
     port=settings.redis_port,

--- a/strider/config.py
+++ b/strider/config.py
@@ -20,10 +20,10 @@ class Settings(BaseSettings):
     redis_password: str = "supersecretpassword"
 
     jaeger_enabled: str = "True"
-    # OTLP span exporter endpoint. When left unset the exporter falls back to the
-    # standard OTEL_EXPORTER_OTLP_ENDPOINT env var, which the OpenTelemetry
-    # operator injects automatically in Kubernetes.
-    otlp_endpoint: Optional[str] = None
+    jaeger_host: str = "jaeger"
+    # 4317 is Jaeger's native OTLP gRPC receiver (replaces the old 6831
+    # thrift-agent port, which newer OpenTelemetry SDKs no longer support).
+    jaeger_port: int = 4317
 
     profiler: bool = False
     use_cache: bool = True

--- a/strider/config.py
+++ b/strider/config.py
@@ -20,8 +20,10 @@ class Settings(BaseSettings):
     redis_password: str = "supersecretpassword"
 
     jaeger_enabled: str = "True"
-    jaeger_host: str = "jaeger"
-    jaeger_port: int = 6831
+    # OTLP span exporter endpoint. When left unset the exporter falls back to the
+    # standard OTEL_EXPORTER_OTLP_ENDPOINT env var, which the OpenTelemetry
+    # operator injects automatically in Kubernetes.
+    otlp_endpoint: Optional[str] = None
 
     profiler: bool = False
     use_cache: bool = True

--- a/strider/normalizer.py
+++ b/strider/normalizer.py
@@ -14,7 +14,6 @@ from .utils import (
 )
 from .config import settings
 
-
 Entity = namedtuple(
     "Entity", ["categories", "identifiers", "information_content", "preferred_curie"]
 )

--- a/strider/server.py
+++ b/strider/server.py
@@ -170,9 +170,11 @@ if settings.jaeger_enabled == "True":
     logging.captureWarnings(capture=True)
     warnings.filterwarnings("ignore", category=ResourceWarning)
     service_name = os.environ.get("OTEL_SERVICE_NAME", "STRIDER")
-    # Jaeger ingests OTLP natively (gRPC on 4317). A falsy endpoint lets the
-    # exporter read OTEL_EXPORTER_OTLP_ENDPOINT, set by the OTel operator in k8s.
-    otlp_exporter = OTLPSpanExporter(endpoint=settings.otlp_endpoint or None)
+    # Jaeger ingests OTLP natively (gRPC on 4317). The http:// scheme selects an
+    # insecure channel, matching the old plaintext agent connection.
+    otlp_exporter = OTLPSpanExporter(
+        endpoint=f"http://{settings.jaeger_host}:{settings.jaeger_port}",
+    )
     resource = Resource(attributes={SERVICE_NAME: service_name})
     provider = TracerProvider(resource=resource)
     processor = BatchSpanProcessor(otlp_exporter)

--- a/strider/server.py
+++ b/strider/server.py
@@ -149,11 +149,13 @@ async def catch_exceptions_middleware(request: Request, call_next):
 APP.middleware("http")(catch_exceptions_middleware)
 
 if settings.jaeger_enabled == "True":
-    LOGGER.info("Starting up Jaeger")
+    LOGGER.info("Starting up OpenTelemetry tracing")
 
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
     from opentelemetry import trace
-    from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+        OTLPSpanExporter,
+    )
     from opentelemetry.sdk.resources import (
         SERVICE_NAME,
         Resource,
@@ -168,13 +170,12 @@ if settings.jaeger_enabled == "True":
     logging.captureWarnings(capture=True)
     warnings.filterwarnings("ignore", category=ResourceWarning)
     service_name = os.environ.get("OTEL_SERVICE_NAME", "STRIDER")
-    jaeger_exporter = JaegerExporter(
-        agent_host_name=settings.jaeger_host,
-        agent_port=int(settings.jaeger_port),
-    )
+    # Jaeger ingests OTLP natively (gRPC on 4317). A falsy endpoint lets the
+    # exporter read OTEL_EXPORTER_OTLP_ENDPOINT, set by the OTel operator in k8s.
+    otlp_exporter = OTLPSpanExporter(endpoint=settings.otlp_endpoint or None)
     resource = Resource(attributes={SERVICE_NAME: service_name})
     provider = TracerProvider(resource=resource)
-    processor = BatchSpanProcessor(jaeger_exporter)
+    processor = BatchSpanProcessor(otlp_exporter)
     provider.add_span_processor(processor)
     trace.set_tracer_provider(provider)
     FastAPIInstrumentor.instrument_app(

--- a/strider/server.py
+++ b/strider/server.py
@@ -74,7 +74,7 @@ openapi_args = dict(
     title="Strider",
     description=DESCRIPTION,
     docs_url=None,
-    version="4.8.5",
+    version="4.8.6",
     terms_of_service=(
         "http://robokop.renci.org:7055/tos"
         "?service_long=Strider"

--- a/tests/helpers/redisMock.py
+++ b/tests/helpers/redisMock.py
@@ -4,7 +4,6 @@ import fakeredis.aioredis as fakeredis
 import gzip
 import json
 
-
 default_kps = {
     "kp0": {
         "url": "http://kp0/query",

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -52,14 +52,12 @@ async def test_fetcher_bad_response(monkeypatch, httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         url="http://kp1/query", json=mock_responses.response_with_pinned_node_subclasses
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( categories[] biolink:Disease ))
         n0(( ids[] MONDO:0005011 ))
         n0-- biolink:related_to -->n1
         n1(( category biolink:NamedThing ))
-        """
-    )
+        """)
     message = {"query_graph": QGRAPH}
 
     fetcher = Fetcher(logger, False, {})

--- a/tests/test_kp_responses.py
+++ b/tests/test_kp_responses.py
@@ -31,14 +31,12 @@ async def test_kp_response_empty_message(monkeypatch, httpx_mock: HTTPXMock):
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(url="http://kp1/query", json={"message": {}})
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( categories[] biolink:Drug ))
         n0(( ids[] CHEBI:6801 ))
         n0-- biolink:treats -->n1
         n1(( categories[] biolink:Disease ))
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj(
@@ -67,16 +65,14 @@ async def test_kp_response_empty_message_pinned_two_hop(
     # mock the return of the kp registry from redis
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(url="http://kp2/query", json={"message": {}})
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] MONDO:1 ))
         n0-- biolink:related_to -->n1
         n1(( categories[] biolink:Gene ))
         n1-- biolink:related_to -->n2
         n2(( ids[] MONDO:2 ))
 
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj(
@@ -105,14 +101,12 @@ async def test_kp_500(monkeypatch, httpx_mock: HTTPXMock):
         url="http://kp0/query", status_code=500, text="Internal Server Error"
     )
     httpx_mock.add_response(url="http://kp1/query", json=mock_responses.kp_response)
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:SmallMolecule ))
         n1(( categories[] biolink:Disease ))
         n0-- biolink:treats -->n1
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj(
@@ -140,14 +134,12 @@ async def test_kp_not_trapi(monkeypatch, httpx_mock: HTTPXMock):
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(url="http://kp1/query", json={"message": None})
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( categories[] biolink:Disease ))
         n0(( ids[] MONDO:0005737 ))
         n0-- biolink:treated_by -->n1
         n1(( categories[] biolink:Drug ))
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj(
@@ -179,14 +171,12 @@ async def test_kp_no_kg(monkeypatch, httpx_mock: HTTPXMock):
         url="http://kp1/query",
         json={"message": {"query_graph": {"nodes": {}, "edges": {}}}},
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( categories[] biolink:SmallMolecule ))
         n0(( ids[] CHEBI:0001 ))
         n0-- biolink:treats -->n1
         n1(( categories[] biolink:Disease ))
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj({"message": {"query_graph": QGRAPH}})
@@ -215,14 +205,12 @@ async def test_kp_response_no_qg(monkeypatch, httpx_mock: HTTPXMock):
         },
     )
     httpx_mock.add_response(url="http://kp1/query", json=mock_responses.kp_response)
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( categories[] biolink:SmallMolecule ))
         n0(( ids[] CHEBI:6801 ))
         n0-- biolink:treats -->n1
         n1(( categories[] biolink:Disease ))
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj({"message": {"query_graph": QGRAPH}})
@@ -299,14 +287,12 @@ async def test_constraint_error(monkeypatch, httpx_mock: HTTPXMock):
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(url="http://kp1/query", json=constraint_error_response)
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:SmallMolecule ))
         n0-- biolink:treats -->n1
         n1(( categories[] biolink:Disease ))
-        """
-    )
+        """)
 
     QGRAPH["nodes"]["n1"]["constraints"] = [
         {

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -31,14 +31,12 @@ async def test_mixed_canonical(monkeypatch, mocker):
         "strider.throttle.ThrottledServer._query",
         return_value=PydanticResponse.parse_obj({"message": {}}),
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:ChemicalSubstance ))
         n1(( categories[] biolink:Disease ))
         n0-- biolink:treats biolink:phenotype_of -->n1
-        """
-    )
+        """)
 
     # Create query
     q = {
@@ -94,14 +92,12 @@ async def test_symmetric_noncanonical(monkeypatch, mocker):
         "strider.throttle.ThrottledServer._query",
         return_value=PydanticResponse.parse_obj({"message": {}}),
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:ChemicalSubstance ))
         n1(( categories[] biolink:Disease ))
         n0-- biolink:genetically_interacts_with -->n1
-        """
-    )
+        """)
 
     # Create query
     q = {
@@ -158,13 +154,11 @@ async def test_disambiguation(monkeypatch, httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         url="http://kp1/query", json=mock_responses.disambiguation_response
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0-- biolink:treats -->n1
         n1(( categories[] biolink:Disease ))
-        """
-    )
+        """)
 
     # Create query
     q = {
@@ -184,13 +178,11 @@ async def test_trivial_unbatching(monkeypatch, httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         url="http://kp1/query", json=mock_responses.unbatching_response
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0-- biolink:treats -->n1
         n1(( categories[] biolink:Disease ))
-        """
-    )
+        """)
 
     # Create query
     q = {
@@ -212,14 +204,12 @@ async def test_protein_gene_conflation(monkeypatch, mocker):
         "strider.throttle.ThrottledServer._query",
         return_value=PydanticResponse.parse_obj({"message": {}}),
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] MONDO:0008114 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:Protein ))
         n0-- biolink:related_to -->n1
-        """
-    )
+        """)
 
     # Create query
     q = {"message": {"query_graph": QGRAPH}, "log_level": "INFO"}
@@ -273,14 +263,12 @@ async def test_gene_protein_conflation(monkeypatch, mocker):
         "strider.throttle.ThrottledServer._query",
         return_value=PydanticResponse.parse_obj({"message": {}}),
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( categories[] biolink:Gene ))
         n1(( ids[] MONDO:0008114 ))
         n1(( categories[] biolink:Disease ))
         n0-- biolink:related_to -->n1
-        """
-    )
+        """)
 
     # Create query
     q = {"message": {"query_graph": QGRAPH}, "log_level": "INFO"}
@@ -333,14 +321,12 @@ async def test_node_set(monkeypatch, mocker):
         "strider.throttle.ThrottledServer._query",
         return_value=PydanticResponse.parse_obj({"message": {}}),
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:ChemicalSubstance ))
         n1(( categories[] biolink:Disease ))
         n0-- biolink:treats -->n1
-        """
-    )
+        """)
     QGRAPH["nodes"]["n1"]["set_interpretation"] = "ALL"
 
     # Create query
@@ -397,14 +383,12 @@ async def test_bypass_cache_is_sent_along_to_kps(monkeypatch, mocker):
         "strider.throttle.ThrottledServer._query",
         return_value=PydanticResponse.parse_obj({"message": {}}),
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:ChemicalSubstance ))
         n1(( categories[] biolink:Disease ))
         n0-- biolink:treats -->n1
-        """
-    )
+        """)
 
     # Create query
     q = {

--- a/tests/test_postproc.py
+++ b/tests/test_postproc.py
@@ -37,13 +37,11 @@ async def test_node_filtered(httpx_mock: HTTPXMock):
     """
     httpx_mock.add_response(
         url="http://normalizer/get_normalized_nodes",
-        json=get_normalizer_response(
-            """
+        json=get_normalizer_response("""
             MONDO:0005148 categories biolink:Disease
             MONDO:0005148 synonyms DOID:9352
             MONDO:0005148 information_content 2
-        """
-        ),
+        """),
     )
     provider = KnowledgeProvider("test", kp, logger)
 
@@ -70,8 +68,7 @@ async def test_aux_graph_filtering(httpx_mock: HTTPXMock):
     """
     httpx_mock.add_response(
         url="http://normalizer/get_normalized_nodes",
-        json=get_normalizer_response(
-            """
+        json=get_normalizer_response("""
             MONDO:0005148 categories biolink:Disease
             MONDO:0005148 synonyms DOID:9352
             MONDO:0005148 information_content 100
@@ -81,8 +78,7 @@ async def test_aux_graph_filtering(httpx_mock: HTTPXMock):
             MESH:D014867 categories biolink:ChemicalEntity
             MESH:D014867 synonyms PUBCHEM.COMPOUND:4901
             MESH:D014867 information_content 74
-        """
-        ),
+        """),
     )
     provider = KnowledgeProvider("test", kp, logger)
 
@@ -111,12 +107,10 @@ async def test_blocklist(httpx_mock: HTTPXMock):
     """
     httpx_mock.add_response(
         url="http://normalizer/get_normalized_nodes",
-        json=get_normalizer_response(
-            """
+        json=get_normalizer_response("""
             MESH:D014867 categories biolink:SmallMolecule
             MESH:D014867 synonyms MESH:D000838
-        """
-        ),
+        """),
     )
     provider = KnowledgeProvider("test", kp, logger)
 
@@ -145,16 +139,14 @@ async def test_aux_graph_edges_are_kept(httpx_mock: HTTPXMock):
     """
     httpx_mock.add_response(
         url="http://normalizer/get_normalized_nodes",
-        json=get_normalizer_response(
-            """
+        json=get_normalizer_response("""
             MONDO:0005148 categories biolink:Disease
             MONDO:0005148 synonyms DOID:9352
             MONDO:0005148 information_content 100
             MESH:D008687 categories biolink:ChemicalEntity
             MESH:D008687 synonyms PUBCHEM.COMPOUND:4901
             MESH:D008687 information_content 100
-        """
-        ),
+        """),
     )
     provider = KnowledgeProvider("test", kp, logger)
 
@@ -207,16 +199,14 @@ async def test_nested_aux_graphs(httpx_mock: HTTPXMock):
     """
     httpx_mock.add_response(
         url="http://normalizer/get_normalized_nodes",
-        json=get_normalizer_response(
-            """
+        json=get_normalizer_response("""
             MONDO:0005148 categories biolink:Disease
             MONDO:0005148 synonyms DOID:9352
             MONDO:0005148 information_content 100
             MESH:D008687 categories biolink:ChemicalEntity
             MESH:D008687 synonyms PUBCHEM.COMPOUND:4901
             MESH:D008687 information_content 100
-        """
-        ),
+        """),
     )
     provider = KnowledgeProvider("test", kp, logger)
 

--- a/tests/test_query_planner.py
+++ b/tests/test_query_planner.py
@@ -33,13 +33,11 @@ async def test_not_enough_kps(monkeypatch):
     that has edges we can't solve
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( categories[] biolink:ExposureEvent ))
         n1(( categories[] biolink:Drug ))
         n0-- biolink:related_to -->n1
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
 
     with pytest.raises(NoAnswersError, match=r"cannot reach"):
@@ -54,14 +52,12 @@ async def test_plan_reverse_edge(monkeypatch):
     direction of one that was given
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] MONDO:0005148 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:Drug ))
         n1-- biolink:treats -->n0
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
 
     plan, kps = await generate_plan(qg, {})
@@ -76,8 +72,7 @@ async def test_plan_loop(monkeypatch):
     Test that we create a plan for a query with a loop
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] MONDO:0008114 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:PhenotypicFeature ))
@@ -85,8 +80,7 @@ async def test_plan_loop(monkeypatch):
         n0-- biolink:has_phenotype -->n1
         n2-- biolink:treats -->n0
         n2-- biolink:treats -->n1
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
 
     plan, _ = await generate_plan(qg, {})
@@ -100,8 +94,7 @@ async def test_plan_reuse_pinned(monkeypatch):
     Test that we create a plan that uses a pinned node twice
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] MONDO:0005148 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:Disease ))
@@ -111,8 +104,7 @@ async def test_plan_reuse_pinned(monkeypatch):
         n1-- biolink:related_to -->n2
         n2-- biolink:related_to -->n0
         n0-- biolink:related_to -->n3
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
 
     plan, kps = await generate_plan(qg, {})
@@ -124,8 +116,7 @@ async def test_plan_double_loop(monkeypatch):
     Test valid plan for a more complex query with two loops
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] MONDO:0005148 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:Disease ))
@@ -138,8 +129,7 @@ async def test_plan_double_loop(monkeypatch):
         n2-- biolink:related_to -->n3
         n3-- biolink:related_to -->n4
         n4-- biolink:related_to -->n2
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
     plan, kps = await generate_plan(qg, {})
 
@@ -152,16 +142,14 @@ async def test_valid_two_pinned_nodes(monkeypatch):
     a path from a pinned node to all unbound nodes.
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] MONDO:0005148 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:Drug ))
         n0-- biolink:treated_by -->n1
         n2(( ids[] MONDO:0011122 ))
         n2(( categories[] biolink:Disease ))
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
     await prepare_query_graph(qg)
 
@@ -177,16 +165,14 @@ async def test_fork(monkeypatch):
     a fork to multiple paths.
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] MONDO:0005148 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:Drug ))
         n2(( categories[] biolink:PhenotypicFeature ))
         n0-- biolink:treated_by -->n1
         n0-- biolink:has_phenotype -->n2
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
 
     plan, kps = await generate_plan(qg, {})
@@ -200,14 +186,12 @@ async def test_unbound_unconnected_node(monkeypatch):
     to the unbound node
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] MONDO:0005148 ))
         n1(( categories[] biolink:Drug ))
         n0-- biolink:treated_by -->n1
         n2(( categories[] biolink:PhenotypicFeature ))
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
     await prepare_query_graph(qg)
     print(qg)
@@ -224,8 +208,7 @@ async def test_valid_two_disconnected_components(monkeypatch):
     a pinned node to all unbound nodes.
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] MONDO:0005148 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:Drug ))
@@ -234,8 +217,7 @@ async def test_valid_two_disconnected_components(monkeypatch):
         n2(( categories[] biolink:Disease ))
         n3(( categories[] biolink:Drug ))
         n2-- biolink:treated_by -->n3
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
     plan, kps = await generate_plan(qg, {})
     assert plan == {"n0n1": ["infores:kp1"], "n2n3": ["infores:kp1"]}
@@ -278,14 +260,12 @@ async def test_double_sided(monkeypatch):
     Test planning when a KP provides edges in both directions.
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] MONDO:0005737 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:Drug ))
         n0-- biolink:treated_by -->n1
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
     plan, kps = await generate_plan(qg, {}, logger=logging.getLogger())
     assert plan == {"n0n1": ["infores:kp1"]}
@@ -395,14 +375,12 @@ async def test_inverse_predicate(monkeypatch):
     the inverse of a given predicate to get the right answer.
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( categories[] biolink:Disease ))
         n1(( ids[] CHEBI:6801 ))
         n1(( categories[] biolink:Drug ))
         n0-- biolink:treated_by -->n1
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
 
     plan, kps = await generate_plan(qg, {}, logger=logging.getLogger())
@@ -416,14 +394,12 @@ async def test_symmetric_predicate(monkeypatch):
     Test that we get a kp in the plan with reverse categories and a symmetric predicate.
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( categories[] biolink:Disease ))
         n0(( ids[] MONDO:0005148 ))
         n1(( categories[] biolink:Drug ))
         n1-- biolink:correlated_with -->n0
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
     plan, kps = await generate_plan(qg, {}, logger=logging.getLogger())
     assert plan == {"n1n0": ["infores:kp1"]}
@@ -461,14 +437,12 @@ async def test_solve_double_subclass(monkeypatch):
     it and contact all KPs available for information about that node
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] MONDO:1 ))
         n0(( categories[] biolink:NamedThing ))
         n1(( categories[] biolink:NamedThing ))
         n0-- biolink:ameliorates -->n1
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
 
     plan, kps = await generate_plan(qg, {}, logger=logging.getLogger())
@@ -483,15 +457,13 @@ async def test_pinned_to_pinned(monkeypatch):
     connected to another pinned node
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] MONDO:1 ))
         n0(( categories[] biolink:Disease ))
         n1(( ids[] CHEBI:1 ))
         n1(( categories[] biolink:NucleicAcidEntity ))
         n0-- biolink:related_to -->n1
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
 
     plan, kps = await generate_plan(qg, {}, logger=logging.getLogger())
@@ -505,13 +477,11 @@ async def test_self_edge(monkeypatch):
     Test that we can solve a query with a self-edge
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    qg = query_graph_from_string(
-        """
+    qg = query_graph_from_string("""
         n0(( ids[] CHEBI:1 ))
         n0(( categories[] biolink:Gene ))
         n0-- biolink:related_to -->n0
-        """
-    )
+        """)
     qg = QueryGraph.parse_obj(qg)
 
     # await prepare_query_graph(qg)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -58,14 +58,12 @@ async def test_duplicate_results(monkeypatch, httpx_mock: HTTPXMock):
     httpx_mock.add_response(
         url="http://kp1/query", json=mock_responses.duplicate_result_response_2
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:SmallMolecule ))
         n1(( categories[] biolink:DiseaseOrPhenotypicFeature ))
         n0-- biolink:related_to -->n1
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj({"message": {"query_graph": QGRAPH}})
@@ -91,14 +89,12 @@ async def test_merge_results_different_predicates(monkeypatch, httpx_mock: HTTPX
         url="http://kp1/query",
         json=mock_responses.duplicate_result_response_different_predicate,
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:SmallMolecule ))
         n1(( categories[] biolink:Disease ))
         n0-- biolink:related_to -->n1
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj({"message": {"query_graph": QGRAPH}})
@@ -123,14 +119,12 @@ async def test_solve_missing_predicate(monkeypatch, mocker):
         "strider.throttle.ThrottledServer._query",
         return_value=PydanticResponse.parse_obj({"message": {}}),
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] HP:001 ))
         n0(( categories[] biolink:Gene ))
         n1(( categories[] biolink:Gene ))
         n0-- biolink:treats -->n1
-        """
-    )
+        """)
 
     del QGRAPH["edges"]["n0n1"]["predicates"]
 
@@ -185,14 +179,12 @@ async def test_solve_missing_category(monkeypatch, mocker):
         "strider.throttle.ThrottledServer._query",
         return_value=PydanticResponse.parse_obj({"message": {}}),
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:SmallMolecule ))
         n1(( categories[] biolink:NucleicAcidEntity ))
         n0-- biolink:treats -->n1
-        """
-    )
+        """)
 
     del QGRAPH["nodes"]["n0"]["categories"]
 
@@ -250,24 +242,20 @@ async def test_normalizer_different_category(
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(
         url="http://normalizer/get_normalized_nodes",
-        json=get_normalizer_response(
-            """
+        json=get_normalizer_response("""
             CHEBI:6801 categories biolink:NucleicAcidEntity
-        """
-        ),
+        """),
     )
     query = mocker.patch(
         "strider.throttle.ThrottledServer._query",
         return_value=PydanticResponse.parse_obj({"message": {}}),
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n1(( categories[] biolink:SmallMolecule ))
         n1(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:Disease ))
         n0-- biolink:treats -->n1
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj({"message": {"query_graph": QGRAPH}})
@@ -322,23 +310,19 @@ async def test_solve_loop(monkeypatch, httpx_mock: HTTPXMock):
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(
         url="http://normalizer/get_normalized_nodes",
-        json=get_normalizer_response(
-            """
+        json=get_normalizer_response("""
             MONDO:0008114 categories biolink:Disease
-        """
-        ),
+        """),
     )
     httpx_mock.add_response(url="http://kp1/query", json=mock_responses.kp_response)
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] MONDO:0008114 ))
         n1(( categories[] biolink:SmallMolecule ))
         n2(( categories[] biolink:PhenotypicFeature ))
         n0-- biolink:related_to -->n1
         n1-- biolink:related_to -->n2
         n2-- biolink:related_to -->n0
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj({"message": {"query_graph": QGRAPH}})
@@ -352,14 +336,12 @@ async def test_log_level_param(monkeypatch, httpx_mock: HTTPXMock):
     """Test that changing the log level changes the output"""
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(url="http://kp1/query", json=mock_responses.kp_response)
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:SmallMolecule ))
         n1(( categories[] biolink:PhenotypicFeature ))
         n0-- biolink:treats -->n1
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj({"message": {"query_graph": QGRAPH}})
@@ -428,24 +410,20 @@ async def test_solve_not_real_predicate(monkeypatch, mocker, httpx_mock: HTTPXMo
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(
         url="http://normalizer/get_normalized_nodes",
-        json=get_normalizer_response(
-            """
+        json=get_normalizer_response("""
             CHEBI:6801 categories biolink:SmallMolecule
             MONDO:0005148 categories biolink:Disease
-        """
-        ),
+        """),
     )
     query = mocker.patch(
         "strider.throttle.ThrottledServer._query",
         return_value=PydanticResponse.parse_obj({"message": {}}),
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n1(( categories[] biolink:Disease ))
         n0-- biolink:not_a_real_predicate -->n1
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj({"message": {"query_graph": QGRAPH}, "log_level": "INFO"})
@@ -490,13 +468,11 @@ async def test_normalizer_unavailable(monkeypatch):
     Test that we log a message properly if the Node Normalizer is not available.
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0-- biolink:treats -->n1
         n1(( categories[] biolink:Disease ))
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj(
@@ -523,14 +499,12 @@ async def test_workflow(monkeypatch, httpx_mock: HTTPXMock):
     """
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(url="http://kp1/query", json=mock_responses.kp_response)
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:SmallMolecule ))
         n1(( categories[] biolink:Disease ))
         n0-- biolink:treats -->n1
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj(
@@ -559,8 +533,7 @@ async def test_multiple_identifiers(monkeypatch, httpx_mock: HTTPXMock):
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(
         url="http://normalizer/get_normalized_nodes",
-        json=get_normalizer_response(
-            """
+        json=get_normalizer_response("""
             UMLS:C0032961 categories biolink:PhenotypicFeature
             UMLS:C0032961 synonyms NCIT:C25742 NCIT:C92933
             NCIT:C25742 categories biolink:PhenotypicFeature
@@ -569,17 +542,14 @@ async def test_multiple_identifiers(monkeypatch, httpx_mock: HTTPXMock):
             NCIT:C92933 synonyms NCIT:C25742 NCIT:C92933
             CHEBI:2904 categories biolink:SmallMolecule
             CHEBI:30146 categories biolink:SmallMolecule
-        """
-        ),
+        """),
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( categories[] biolink:SmallMolecule ))
         n1(( categories[] biolink:PhenotypicFeature ))
         n1(( ids[] UMLS:C0032961 ))
         n0-- biolink:contraindicated_for -->n1
-        """
-    )
+        """)
 
     # Create query
     q = Query.parse_obj({"message": {"query_graph": QGRAPH}})
@@ -597,22 +567,18 @@ async def test_provenance(monkeypatch, httpx_mock: HTTPXMock):
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(
         url="http://normalizer/get_normalized_nodes",
-        json=get_normalizer_response(
-            """
+        json=get_normalizer_response("""
             MONDO:0005148 categories biolink:NucleicAcidEntity
-        """
-        ),
+        """),
     )
     httpx_mock.add_response(
         url="http://kp3/query", json=mock_responses.response_with_attributes
     )
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] MONDO:0005148 ))
         n1(( categories[] biolink:NamedThing ))
         n0-- biolink:related_to -->n1
-        """
-    )
+        """)
     q = Query.parse_obj({"message": {"query_graph": QGRAPH}})
 
     # Run
@@ -638,14 +604,12 @@ async def test_async_query(monkeypatch, httpx_mock: HTTPXMock):
     monkeypatch.setattr(redis.asyncio, "Redis", redisMock)
     httpx_mock.add_response(url="http://kp1/query", json=mock_responses.kp_response)
     httpx_mock.add_response(url=callback_url, status_code=200)
-    QGRAPH = query_graph_from_string(
-        """
+    QGRAPH = query_graph_from_string("""
         n0(( ids[] CHEBI:6801 ))
         n0(( categories[] biolink:SmallMolecule ))
         n1(( categories[] biolink:Disease ))
         n0-- biolink:treats -->n1
-        """
-    )
+        """)
 
     # Run
     await async_lookup(
@@ -659,22 +623,18 @@ async def test_async_query(monkeypatch, httpx_mock: HTTPXMock):
 @pytest.mark.asyncio
 async def test_different_callbacks_multiquery():
     """Test multiquery endpoint fails with different callbacks."""
-    QGRAPH1 = query_graph_from_string(
-        """
+    QGRAPH1 = query_graph_from_string("""
         n0(( ids[] MONDO:0005148 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:SmallMolecule ))
         n1-- biolink:treats -->n0
-        """
-    )
-    QGRAPH2 = query_graph_from_string(
-        """
+        """)
+    QGRAPH2 = query_graph_from_string("""
         n0(( ids[] MONDO:0005148 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:PhenotypicFeature ))
         n0-- biolink:has_phenotype -->n1
-        """
-    )
+        """)
 
     q_error = {
         "query1": AsyncQuery.parse_obj(
@@ -701,22 +661,18 @@ async def test_multi_lookup(monkeypatch, httpx_mock: HTTPXMock):
     httpx_mock.add_response(url="http://kp3/query", json=mock_responses.kp_response)
     httpx_mock.add_response(url=callback_url, match_json=expected_status)
     httpx_mock.add_response(url=callback_url, status_code=200)
-    QGRAPH1 = query_graph_from_string(
-        """
+    QGRAPH1 = query_graph_from_string("""
         n1(( ids[] MONDO:0005148 ))
         n1(( categories[] biolink:Disease ))
         n0(( categories[] biolink:NucleicAcidEntity ))
         n1-- biolink:treats -->n0
-        """
-    )
-    QGRAPH2 = query_graph_from_string(
-        """
+        """)
+    QGRAPH2 = query_graph_from_string("""
         n0(( ids[] MONDO:0005148 ))
         n0(( categories[] biolink:Disease ))
         n1(( categories[] biolink:PhenotypicFeature ))
         n0-- biolink:has_phenotype -->n1
-        """
-    )
+        """)
 
     q = {
         "query1": {


### PR DESCRIPTION
The Jaeger native exporters were removed from the OpenTelemetry SDK (>=1.28). In production the OTel operator injects a recent SDK at /otel-auto-instrumentation-python and prepends it to PYTHONPATH, so the pinned opentelemetry-exporter-jaeger==1.21.0 crashed on startup with:

  ImportError: cannot import name 'OTEL_EXPORTER_JAEGER_AGENT_HOST'
  from 'opentelemetry.sdk.environment_variables'

Switch to the OTLP gRPC span exporter (Jaeger ingests OTLP natively on 4317). With no configured endpoint the exporter reads the standard OTEL_EXPORTER_OTLP_ENDPOINT env var that the operator injects, so prod defers to the operator while local dev points at the jaeger service.

- server.py: JaegerExporter -> OTLPSpanExporter
- config.py: replace jaeger_host/jaeger_port with otlp_endpoint
- requirements: drop opentelemetry-exporter-jaeger, add otlp-proto-grpc
- docker-compose.dev.yml: expose Jaeger OTLP ports, set OTLP_ENDPOINT