### PR TITLE
Remove OpenTelemetry (OTEL) tracing code

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,28 +6,3 @@ services:
     volumes:
       - ./:/app
     command: --bind 0.0.0.0:5781 --reload
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    container_name: jaeger
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
-    ports:
-      - "4317:4317"   # OTLP gRPC
-      - "4318:4318"   # OTLP HTTP
-      - "16686:16686" # Jaeger UI
-    networks:
-      - strider
-  hotrod:
-    image: jaegertracing/example-hotrod:latest
-    ports: 
-      - "8080:8080"
-    command: ["all"]
-    environment:
-      - JAEGER_AGENT_HOST=jaeger
-      # Note: if your application is using Node.js Jaeger Client, you need port 6832,
-      #       unless issue https://github.com/jaegertracing/jaeger/issues/1596 is resolved.
-      - JAEGER_AGENT_PORT=6831
-    networks:
-      - strider
-    depends_on:
-      - jaeger

--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -35,17 +35,6 @@ linkml-runtime==1.8.3
 markdown-it-py==3.0.0
 MarkupSafe==2.1.5
 mdurl==0.1.2
-opentelemetry-api==1.42.1
-opentelemetry-exporter-otlp-proto-common==1.42.1
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
-opentelemetry-instrumentation==0.63b1
-opentelemetry-instrumentation-asgi==0.63b1
-opentelemetry-instrumentation-fastapi==0.63b1
-opentelemetry-instrumentation-httpx==0.63b1
-opentelemetry-proto==1.42.1
-opentelemetry-sdk==1.42.1
-opentelemetry-semantic-conventions==0.63b1
-opentelemetry-util-http==0.63b1
 orjson==3.10.3
 packaging==24.1
 pluggy==1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,4 @@ redis==5.0.6
 orjson==3.10.3
 gunicorn==22.0.0
 kp-registry==4.0.1
-opentelemetry-sdk==1.42.1
-opentelemetry-instrumentation-fastapi==0.63b1
-opentelemetry-exporter-otlp-proto-grpc==1.42.1
-opentelemetry-instrumentation-httpx==0.63b1
 pyinstrument==4.6.2

--- a/strider/config.py
+++ b/strider/config.py
@@ -19,12 +19,6 @@ class Settings(BaseSettings):
     redis_expiration: int = 1209600  # two weeks
     redis_password: str = "supersecretpassword"
 
-    jaeger_enabled: str = "True"
-    jaeger_host: str = "jaeger"
-    # 4317 is Jaeger's native OTLP gRPC receiver (replaces the old 6831
-    # thrift-agent port, which newer OpenTelemetry SDKs no longer support).
-    jaeger_port: int = 4317
-
     profiler: bool = False
     use_cache: bool = True
     offline_mode: bool = False

--- a/strider/server.py
+++ b/strider/server.py
@@ -11,10 +11,8 @@ oo     .d8P   888 .  888      888  888   888  888    .o  888
 import copy
 import datetime
 import json
-import os
 import uuid
 import logging
-import warnings
 import time
 import traceback
 import asyncio
@@ -147,43 +145,6 @@ async def catch_exceptions_middleware(request: Request, call_next):
 
 
 APP.middleware("http")(catch_exceptions_middleware)
-
-if settings.jaeger_enabled == "True":
-    LOGGER.info("Starting up OpenTelemetry tracing")
-
-    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-    from opentelemetry import trace
-    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-        OTLPSpanExporter,
-    )
-    from opentelemetry.sdk.resources import (
-        SERVICE_NAME,
-        Resource,
-    )
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor
-    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
-
-    # httpx connections need to be open a little longer by the otel decorators
-    # but some libs display warnings of resource being unclosed.
-    # these supresses such warnings.
-    logging.captureWarnings(capture=True)
-    warnings.filterwarnings("ignore", category=ResourceWarning)
-    service_name = os.environ.get("OTEL_SERVICE_NAME", "STRIDER")
-    # Jaeger ingests OTLP natively (gRPC on 4317). The http:// scheme selects an
-    # insecure channel, matching the old plaintext agent connection.
-    otlp_exporter = OTLPSpanExporter(
-        endpoint=f"http://{settings.jaeger_host}:{settings.jaeger_port}",
-    )
-    resource = Resource(attributes={SERVICE_NAME: service_name})
-    provider = TracerProvider(resource=resource)
-    processor = BatchSpanProcessor(otlp_exporter)
-    provider.add_span_processor(processor)
-    trace.set_tracer_provider(provider)
-    FastAPIInstrumentor.instrument_app(
-        APP, tracer_provider=provider, excluded_urls="docs,openapi.json"
-    )
-    HTTPXClientInstrumentor().instrument()
 
 
 @APP.on_event("startup")


### PR DESCRIPTION
Remove all OpenTelemetry/Jaeger instrumentation:
- Drop the tracing setup block and unused os/warnings imports in server.py
- Remove jaeger_* settings from config.py
- Remove opentelemetry-* dependencies from requirements.txt and lock
- Remove jaeger and hotrod services from docker-compose.dev.yml